### PR TITLE
Fixes Bug Where Calling FrameVideoView.setup() with Drawable Does Not Play Video

### DIFF
--- a/library/src/main/java/com/mklimek/frameviedoview/FrameVideoView.java
+++ b/library/src/main/java/com/mklimek/frameviedoview/FrameVideoView.java
@@ -88,6 +88,7 @@ public class FrameVideoView extends FrameLayout {
         } else{
             placeholderView.setBackground(placeholderDrawable);
         }
+        impl.init(placeholderView, videoUri);
     }
 
     private View createPlaceholderView(Context context) {


### PR DESCRIPTION
This PR fixes a bug in where calling
```kotlin
frameVideoView.setup(videoUri, ContextCompat.getDrawable(this, R.drawable.my_place_holder_drawable))
```
does not play the video.  The reason the video was not being played was because `impl.init()` was not being called in the setup method that accepts a drawable for the place holder view.